### PR TITLE
fix for deadlock (due to ill-partioned memory)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/modules" ${CMAKE_MODULE_PATH})
 
 project ("warpaffine"
-          VERSION 0.3.1
+          VERSION 0.3.2
           DESCRIPTION "experimental Deskew operation")
 
 option(WARPAFFINE_BUILD_CLANGTIDY "Build with Clang-Tidy" OFF)

--- a/libwarpaffine/warpaffine/WarpAffine_IPP.cpp
+++ b/libwarpaffine/warpaffine/WarpAffine_IPP.cpp
@@ -79,12 +79,12 @@ void WarpAffineIPP::ExecuteMinimalSource(
 
     // As of the time of writing, the IPP has trouble if the source or the destination is
     // beyond 2GB it seems. What we do here - if the source or the destination buffer is 
-    // larger than 2GB, we fall back to the reference implemenation.
+    // larger than 2GB, we fall back to the reference implementation.
     constexpr uint64_t kSafeSizeForIppOperation = numeric_limits<int32_t>::max();
     if (static_cast<uint64_t>(source_brick.info.stride_plane) * integer_source_voi_clipped.depth > kSafeSizeForIppOperation ||
         static_cast<uint64_t>(destination_brick.info.stride_plane) * destination_brick.info.depth > kSafeSizeForIppOperation)
     {
-        // The reference-implemenation currently only supports NN and linear interpolation. What we do here now is
+        // The reference-implementation currently only supports NN and linear interpolation. What we do here now is
         //  that we "silently" map all supported interpolation modes to this.
         // TODO(JBL): this is of course lame
         Interpolation interpolation_mode_adjusted;


### PR DESCRIPTION
In rather pathologic cases, it was possible that the memory reserved for "output-bricks" was insufficient, leading to a deadlock. This fix mitigates the issue, and enables proper operation in this case.