### PR TITLE
Groundwork to allow different illumination angles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/modules" ${CMAKE_MODULE_PATH})
 
 project ("warpaffine"
-          VERSION 0.5.2
+          VERSION 0.5.3
           DESCRIPTION "experimental Deskew operation")
 
 option(WARPAFFINE_BUILD_CLANGTIDY "Build with Clang-Tidy" OFF)

--- a/documentation/version-history.md
+++ b/documentation/version-history.md
@@ -1,12 +1,13 @@
 version history                 {#version_history}
 ============
 
- version            |  PR                                                  | comment
- ------------------ | ---------------------------------------------------- | ---------------------------------------------------
- 0.3.0              |  N/A                                                 | initial release
- 0.3.1              |  [3](https://github.com/ZEISS/warpaffine/pull/3)     | bugfix for a crash for "CZIs containing a single brick but have an S-index"
- 0.3.2              |  [5](https://github.com/ZEISS/warpaffine/pull/5)     | bugfix for a deadlock in rare case
- 0.4.0              |  [6](https://github.com/ZEISS/warpaffine/pull/6)     | set re-tiling id of sub-blocks to allow for more sensible stitching of resulting CZI
- 0.5.0              |  [7](https://github.com/ZEISS/warpaffine/pull/7)     | copy attachments from source document
- 0.5.1              |  [8](https://github.com/ZEISS/warpaffine/pull/8)     | fix z interval metadata for coverglass transformation
- 0.5.2              |  [8](https://github.com/ZEISS/warpaffine/pull/9)     | fix z interval metadata for deskew
+ version            | PR                                                | comment
+ ------------------ |---------------------------------------------------| ---------------------------------------------------
+ 0.3.0              | N/A                                               | initial release
+ 0.3.1              | [3](https://github.com/ZEISS/warpaffine/pull/3)   | bugfix for a crash for "CZIs containing a single brick but have an S-index"
+ 0.3.2              | [5](https://github.com/ZEISS/warpaffine/pull/5)   | bugfix for a deadlock in rare case
+ 0.4.0              | [6](https://github.com/ZEISS/warpaffine/pull/6)   | set re-tiling id of sub-blocks to allow for more sensible stitching of resulting CZI
+ 0.5.0              | [7](https://github.com/ZEISS/warpaffine/pull/7)   | copy attachments from source document
+ 0.5.1              | [8](https://github.com/ZEISS/warpaffine/pull/8)   | fix z interval metadata for coverglass transformation
+ 0.5.2              | [9](https://github.com/ZEISS/warpaffine/pull/9)   | fix z interval metadata for deskew
+ 0.5.3              | [10](https://github.com/ZEISS/warpaffine/pull/10) | prepare changeable illumination angle

--- a/libwarpaffine/deskew_helpers.cpp
+++ b/libwarpaffine/deskew_helpers.cpp
@@ -136,36 +136,35 @@ using namespace std;
 /*static*/Eigen::Matrix4d DeskewHelpers::GetTransformationMatrix_Deskew(const DeskewDocumentInfo& document_info)
 {
     /*
+     The image frames of the z-stack in the CZI correspond to measurement planes that are placed like
+     this in the sample:
 
-    The images are arranged like this:
+          y
+          ↑
+          | α=60° ╱       ╱       ╱
+          |      ╱       ╱       ╱
+          |     ╱       ╱       ╱
+          |    ╱       ╱       ╱
+          |   ╱       ╱       ╱
+          |  ╱       ╱       ╱
+          | ╱       ╱       ╱
+          |╱       ╱       ╱
+          +----------------------------→ z  (cover glass, corresponds to the y-axis of the stage but z in the CZI)
 
+     with an angle of α = 60° in the to the vertical and 90° - α to the cover glass. The deskew operation is a shear
+     transformation that shifts the images of the orthogonal z-stack along the measurement plane so that
+     they match the offsets in the placement above. The fundamental shear coefficient is simply sin(α),
+     which is scaled below as spacings of the z-stack in z- and x-y-direction are different.
 
-|   |--\    x    x    x    x
-    |   -- x    x    x    x
-    |  α  x    x    x    x
-    |    x    x    x    x
-    |   x    x    x    x
-    |  x    x    x    x
-    | x    x    x    x
-    |x    x    x    x
-
-    with an angle of α = 60° to the vertical.
-
+     Note: z_scaling is the physical distance the stage moved during the measurement, i.e., the distance of the
+     planes along the z-axis in the graph above and _NOT_ the orthogonal distance of the planes.
     */
+    double shear_in_pixels = sin(document_info.angle_in_radians) * document_info.z_scaling / document_info.xy_scaling;
 
-    // TODO(Jbl) : I am not sure where this factor of 0.5 comes from (=cos(60°)), or - the z-spacing
-    //              of the source-file is telling us by how much the hardware moved, not how far the z-slices
-    //              are apart from one another I suppose
-    double b = tan(DegreesToRadians(60)) * (document_info.z_scaling * cos(DegreesToRadians(60)));
+    Matrix4d matrix_shear;
+    matrix_shear << 1, 0, 0, 0, 0, 1, shear_in_pixels, 0, 0, 0, 1, 0, 0, 0, 0, 1;
 
-    double b_in_pixels = b / document_info.xy_scaling;
-
-    double total_skew = b_in_pixels * (document_info.depth - 1);
-
-    Matrix4d matrix_skew;
-    matrix_skew << 1, 0, 0, 0, 0, 1, b_in_pixels, 0, 0, 0, 1, 0, 0, 0, 0, 1;
-
-    return matrix_skew;
+    return matrix_shear;
 }
 
 /*static*/Eigen::Matrix4d DeskewHelpers::GetTransformationMatrix_CoverglassTransform(const DeskewDocumentInfo& document_info, bool rotate_around_z_axis_by_90_degree)
@@ -311,4 +310,8 @@ using namespace std;
     integer_cuboid.height = static_cast<std::uint32_t>(llrint(ceil((float_cuboid.y_position - integer_cuboid.y_position) + float_cuboid.height)));
     integer_cuboid.depth = static_cast<std::uint32_t>(llrint(ceil((float_cuboid.z_position - integer_cuboid.z_position) + float_cuboid.depth)));
     return integer_cuboid;
+}
+
+/*static*/double DeskewHelpers::OrthogonalPlaneDistance(const DeskewDocumentInfo& document_info) {
+    return cos(document_info.angle_in_radians) * document_info.z_scaling;
 }

--- a/libwarpaffine/deskew_helpers.cpp
+++ b/libwarpaffine/deskew_helpers.cpp
@@ -151,7 +151,7 @@ using namespace std;
           |╱       ╱       ╱
           +----------------------------→ z  (cover glass, corresponds to the y-axis of the stage but z in the CZI)
 
-     with an angle of α = 60° in the to the vertical and 90° - α to the cover glass. The deskew operation is a shear
+     with an angle of α = 60° to the vertical and 90° - α to the cover glass. The deskew operation is a shear
      transformation that shifts the images of the orthogonal z-stack along the measurement plane so that
      they match the offsets in the placement above. The fundamental shear coefficient is simply sin(α),
      which is scaled below as spacings of the z-stack in z- and x-y-direction are different.
@@ -159,7 +159,7 @@ using namespace std;
      Note: z_scaling is the physical distance the stage moved during the measurement, i.e., the distance of the
      planes along the z-axis in the graph above and _NOT_ the orthogonal distance of the planes.
     */
-    double shear_in_pixels = sin(document_info.angle_in_radians) * document_info.z_scaling / document_info.xy_scaling;
+    const double shear_in_pixels = sin(document_info.illumination_angle_in_radians) * document_info.z_scaling / document_info.xy_scaling;
 
     Matrix4d shearing_matrix;
     shearing_matrix << 1, 0, 0, 0, 0, 1, shear_in_pixels, 0, 0, 0, 1, 0, 0, 0, 0, 1;
@@ -189,7 +189,7 @@ using namespace std;
     scaling_matrix << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, factor_to_scale_z, 0, 0, 0, 0, 1;
 
     // 4. And now we rotate the face of the z-stack to be parallel to the cover glass
-    const auto rotation_around_x_axis = GetRotationAroundXAxis(document_info.angle_in_radians + 0.5 * M_PI);
+    const auto rotation_around_x_axis = GetRotationAroundXAxis(document_info.illumination_angle_in_radians + 0.5 * M_PI);
 
     // construct the full transformation matrix
     Matrix4d m = rotation_around_x_axis * scaling_matrix * shearing_matrix * flip;
@@ -301,5 +301,5 @@ using namespace std;
 }
 
 /*static*/double DeskewHelpers::OrthogonalPlaneDistance(const DeskewDocumentInfo& document_info) {
-    return cos(document_info.angle_in_radians) * document_info.z_scaling;
+    return cos(document_info.illumination_angle_in_radians) * document_info.z_scaling;
 }

--- a/libwarpaffine/deskew_helpers.cpp
+++ b/libwarpaffine/deskew_helpers.cpp
@@ -136,28 +136,28 @@ using namespace std;
 /*static*/Eigen::Matrix4d DeskewHelpers::GetTransformationMatrix_Deskew(const DeskewDocumentInfo& document_info)
 {
     /*
-     The image frames of the z-stack in the CZI correspond to measurement planes that are placed like
-     this in the sample:
+    The image frames of the z-stack in the CZI correspond to measurement planes that are placed like
+    this in the sample:
 
-          y
-          ↑
-          | α=60° ╱       ╱       ╱
-          |      ╱       ╱       ╱
-          |     ╱       ╱       ╱
-          |    ╱       ╱       ╱
-          |   ╱       ╱       ╱
-          |  ╱       ╱       ╱
-          | ╱       ╱       ╱
-          |╱       ╱       ╱
-          +----------------------------→ z  (cover glass, corresponds to the y-axis of the stage but z in the CZI)
+        y
+        ↑
+        | α=60° ╱       ╱       ╱
+        |      ╱       ╱       ╱
+        |     ╱       ╱       ╱
+        |    ╱       ╱       ╱
+        |   ╱       ╱       ╱
+        |  ╱       ╱       ╱
+        | ╱       ╱       ╱
+        |╱       ╱       ╱
+        +----------------------------→ z  (cover glass, corresponds to the y-axis of the stage but z in the CZI)
 
-     with an angle of α = 60° to the vertical and 90° - α to the cover glass. The deskew operation is a shear
-     transformation that shifts the images of the orthogonal z-stack along the measurement plane so that
-     they match the offsets in the placement above. The fundamental shear coefficient is simply sin(α),
-     which is scaled below as spacings of the z-stack in z- and x-y-direction are different.
+    with an angle of α = 60° to the vertical and 90° - α to the cover glass. The deskew operation is a shear
+    transformation that shifts the images of the orthogonal z-stack along the measurement plane so that
+    they match the offsets in the placement above. The fundamental shear coefficient is simply sin(α),
+    which is scaled below as spacings of the z-stack in z- and x-y-direction are different.
 
-     Note: z_scaling is the physical distance the stage moved during the measurement, i.e., the distance of the
-     planes along the z-axis in the graph above and _NOT_ the orthogonal distance of the planes.
+    Note: z_scaling is the physical distance the stage moved during the measurement, i.e., the distance of the
+    planes along the z-axis in the graph above and _NOT_ the orthogonal distance of the planes.
     */
     const double shear_in_pixels = sin(document_info.illumination_angle_in_radians) * document_info.z_scaling / document_info.xy_scaling;
 

--- a/libwarpaffine/deskew_helpers.h
+++ b/libwarpaffine/deskew_helpers.h
@@ -86,6 +86,9 @@ public:
 
     static IntCuboid FromFloatCuboid(const DoubleCuboid& float_cuboid);
 
+    /// Returns the orthogonal distance of the measurement planes from the document info.
+    static double OrthogonalPlaneDistance(const DeskewDocumentInfo& document_info);
+
 private:
     static double DegreesToRadians(double angle_in_degrees);
     static double RadiansToDegrees(double angle_in_radians);

--- a/libwarpaffine/document_info.h
+++ b/libwarpaffine/document_info.h
@@ -142,5 +142,7 @@ struct DeskewDocumentInfo
 
     double          z_scaling{ std::numeric_limits<double>::quiet_NaN() };  ///< The size of one pixel in z-direction in units of micro-meters.
     double          xy_scaling{ std::numeric_limits<double>::quiet_NaN() }; ///< The size of one pixel in x- or y-direction in units of micro-meters.
+
+    const double angle_in_radians = 45.0 / 180.0 * 3.14159265358979323846;
 };
 

--- a/libwarpaffine/document_info.h
+++ b/libwarpaffine/document_info.h
@@ -143,6 +143,6 @@ struct DeskewDocumentInfo
     double          z_scaling{ std::numeric_limits<double>::quiet_NaN() };  ///< The size of one pixel in z-direction in units of micro-meters.
     double          xy_scaling{ std::numeric_limits<double>::quiet_NaN() }; ///< The size of one pixel in x- or y-direction in units of micro-meters.
 
-    const double angle_in_radians = 45.0 / 180.0 * 3.14159265358979323846;
+    const double angle_in_radians = 60.0 / 180.0 * 3.14159265358979323846;
 };
 

--- a/libwarpaffine/document_info.h
+++ b/libwarpaffine/document_info.h
@@ -143,6 +143,8 @@ struct DeskewDocumentInfo
     double          z_scaling{ std::numeric_limits<double>::quiet_NaN() };  ///< The size of one pixel in z-direction in units of micro-meters.
     double          xy_scaling{ std::numeric_limits<double>::quiet_NaN() }; ///< The size of one pixel in x- or y-direction in units of micro-meters.
 
-    const double angle_in_radians = 60.0 / 180.0 * 3.14159265358979323846;
+    /// The angle between the light sheet illumination and the vertical direction,  i.e., the normal of the cover glass.
+    /// This also defines the tilt of the measurement planes with respect to the vertical direction.
+    const double illumination_angle_in_radians = 60.0 / 180.0 * 3.14159265358979323846;
 };
 

--- a/libwarpaffine/main.cpp
+++ b/libwarpaffine/main.cpp
@@ -548,7 +548,7 @@ int libmain(int argc, char** _argv)
         {
             ScalingInfo scaling_info;
             scaling_info.scaleX = scaling_info.scaleY = document_info.xy_scaling;
-            scaling_info.scaleZ = 0.5 * document_info.z_scaling;
+            scaling_info.scaleZ = DeskewHelpers::OrthogonalPlaneDistance(document_info);
             writer->Close(
                 get<0>(reader_and_stream)->ReadMetadataSegment()->CreateMetaFromMetadataSegment(),
                 &scaling_info,
@@ -557,7 +557,7 @@ int libmain(int argc, char** _argv)
         }
         case OperationType::CoverGlassTransform:
         case OperationType::CoverGlassTransformAndXYRotated:
-            // for those operations the transformation is constructed so that the scaling is isotrophic, so
+            // for those operations the transformation is constructed so that the scaling is isotropic, so
             // we know that the scaling in x,y,z is the same (and as the x-y-scaling was in the source)
         {
             ScalingInfo scaling_info;


### PR DESCRIPTION
This PR sets the groundwork to enable different illumination angles in the deskew and coverglass transformation. For now the angle is still hard-coded to 60 degree but this can be set from metadata or command line arguments in a later PR. It also cleans up the transformation creation.