### PR TITLE
Copy the stage coordinates from the subblocks to the output subblocks…

### DIFF
--- a/libwarpaffine/brickreader/IBrickReader.h
+++ b/libwarpaffine/brickreader/IBrickReader.h
@@ -30,6 +30,8 @@ struct BrickCoordinateInfo
     int scene_index;
     int x_position; ///< The x-position of the top-left point of the brick in the document's pixel-coordinate-system.
     int y_position; ///< The y-position of the top-left point of the brick in the document's pixel-coordinate-system.
+    double stage_x_position;
+    double stage_y_position;
 };
 
 /// This interface is used to abstract "reading from the source". It is representing the source, delivering bricks

--- a/libwarpaffine/brickreader/czi_brick_reader2.cpp
+++ b/libwarpaffine/brickreader/czi_brick_reader2.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <memory>
 #include <limits>
+#include <string>
 
 #include "pugixml.hpp"
 

--- a/libwarpaffine/brickreader/czi_brick_reader2.h
+++ b/libwarpaffine/brickreader/czi_brick_reader2.h
@@ -76,4 +76,6 @@ private:
     /// \param          decode_info     If non-null, information describing the decoding.
     /// \param          rectangle       The rectangle.
     void CopySubblockIntoBrick(const libCZI::SubBlockInfo& subblock_info, int z, libCZI::IBitmapData* bitmap, const BrickDecodeInfo* decode_info, const libCZI::IntRect& rectangle);
+
+    static void GetStagePosition(const BrickDecodeInfo* decode_info, BrickCoordinateInfo* brick_coordinate_info);
 };

--- a/libwarpaffine/dowarp.cpp
+++ b/libwarpaffine/dowarp.cpp
@@ -386,6 +386,8 @@ void DoWarp::ProcessBrickCommon2(const Brick& brick, uint32_t brick_id, const Br
                 SubblockXYM xym;
                 xym.x_position = rect_and_tile_identifier.rectangle.x + lround(transformed_and_projected_coordinate.x());
                 xym.y_position = rect_and_tile_identifier.rectangle.y + lround(transformed_and_projected_coordinate.y());
+                xym.stage_x_position = coordinate_info.stage_x_position;
+                xym.stage_y_position = coordinate_info.stage_y_position;
 
                 // TODO(JBL): we better should use optional for this, not magic values
                 if (Utils::IsValidMindex(rect_and_tile_identifier.m_index))
@@ -424,6 +426,8 @@ void DoWarp::ProcessOutputSlice(OutputSliceToCompressTaskInfo* output_slice_task
     add_slice_info.scene_index = xym.scene_index;
     add_slice_info.x_position = xym.x_position;
     add_slice_info.y_position = xym.y_position;
+    add_slice_info.stage_x_position = xym.stage_x_position;
+    add_slice_info.stage_y_position = xym.stage_y_position;
 
     // Only specify a brick_id if there has been a retiling on any destination brick. If it is not necessary,
     // then adding a retiling-id with the output-document is strictly superfluous - so we better don't want to put

--- a/libwarpaffine/geotypes.h
+++ b/libwarpaffine/geotypes.h
@@ -106,6 +106,8 @@ struct SubblockXYM
 {
     int x_position{ 0 };
     int y_position{ 0 };
+    double stage_x_position{ 0 };
+    double stage_y_position{ 0 };
     std::optional<int> m_index;         ///< The m-index of the subblock.
     std::optional<int> scene_index;     ///< The scene-index of the subblock.
 };

--- a/libwarpaffine/sliceswriter/ISlicesWriter.h
+++ b/libwarpaffine/sliceswriter/ISlicesWriter.h
@@ -53,6 +53,12 @@ public:
         /// The brick-id this slice belongs to. If present AND the writer supports it, this id
         /// together with the z-index will be used to construct a retiling-id for the subblock.
         std::optional<std::uint32_t> brick_id;
+        
+        /// The stage x-position of the subblock. This is used to write the stage position into the subblock metadata.
+        double stage_x_position;
+
+        /// The stage y-position of the subblock. This is used to write the stage position into the subblock metadata.
+        double stage_y_position;
     };
 
     /// Gets number of currently pending slice write operations.

--- a/libwarpaffine/sliceswriter/SlicesWriterTbb.h
+++ b/libwarpaffine/sliceswriter/SlicesWriterTbb.h
@@ -12,6 +12,8 @@
 
 #include <tbb/concurrent_queue.h>
 
+#include "pugixml.hpp"
+
 /// Implementation of a ICziSlicesWriter that uses a MPSC-queue to serialize the slice-write operations.
 /// The actual CZI-writing is handled by libCZI.
 class CziSlicesWriterTbb : public ICziSlicesWriter
@@ -43,11 +45,13 @@ public:
     void AddSlice(const AddSliceInfo& add_slice_info) override;
     void AddAttachment(const std::shared_ptr<libCZI::IAttachment>& attachment) override;
     void Close(const std::shared_ptr<libCZI::ICziMetadata>& source_metadata,
-                const libCZI::ScalingInfo* new_scaling_info,
-                const std::function<void(libCZI::IXmlNodeRw*)>& tweak_metadata_hook) override;
+               const libCZI::ScalingInfo* new_scaling_info,
+               const std::function<void(libCZI::IXmlNodeRw*)>& tweak_metadata_hook) override;
 
 private:
     void WriteWorker();
     void CopyMetadata(libCZI::IXmlNodeRead* rootSource, libCZI::IXmlNodeRw* rootDestination);
-    libCZI::GUID CreateRetilingIdWithZandSlice(int z, std::uint32_t slice) const;
+    void AddRetilingId(const SubBlockWriteInfo2& sub_block_write_info, pugi::xml_node& tagsNode) const;
+    libCZI::GUID CreateRetilingIdWithZAndSlice(int z, std::uint32_t slice) const;
+    static void AddStagePosition(const SubBlockWriteInfo2& sub_block_write_info, pugi::xml_node& tagsNode);
 };

--- a/libwarpaffine/sliceswriter/SlicesWriterTbb.h
+++ b/libwarpaffine/sliceswriter/SlicesWriterTbb.h
@@ -45,8 +45,8 @@ public:
     void AddSlice(const AddSliceInfo& add_slice_info) override;
     void AddAttachment(const std::shared_ptr<libCZI::IAttachment>& attachment) override;
     void Close(const std::shared_ptr<libCZI::ICziMetadata>& source_metadata,
-               const libCZI::ScalingInfo* new_scaling_info,
-               const std::function<void(libCZI::IXmlNodeRw*)>& tweak_metadata_hook) override;
+        const libCZI::ScalingInfo* new_scaling_info,
+        const std::function<void(libCZI::IXmlNodeRw*)>& tweak_metadata_hook) override;
 
 private:
     void WriteWorker();


### PR DESCRIPTION
Copy the stage coordinates from the subblocks to the output subblocks to place the images at the correct position in the tiles advanced viewer in zen.